### PR TITLE
Feat: Allow other displays and Raspberry Pi models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 docs/
 out/
+package.json
+run.log

--- a/index.js
+++ b/index.js
@@ -120,6 +120,11 @@ const promptArgs = async (proc) => {
       fallback: "homeassistant",
     },
     {
+      key: "display_type",
+      question: "Do you use an HDMI or DSI display (e.g. Raspberry Pi Touch Display)?",
+      "fallback": "HDMI",
+    },
+    {
       key: "check",
       question: "\nEverything looks good?",
       fallback: "Y/n",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "main": "index.js",
     "scripts": {
-        "start": "electron . --web-url=https://hass.sh-software.info --mqtt-url=mqtt://10.127.100.11:1883 --mqtt-user=tablets --mqtt-password=Baltimore.2014 --display-type=HDMI",
+        "start": "electron . --web-url=https://demo.home-assistant.io --mqtt-url=mqtt://172.0.0.1:1883 --mqtt-user=kiosk --mqtt-password=kiosk --display-type=HDMI",
         "build": "electron-forge make"
     },
     "config": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "main": "index.js",
     "scripts": {
-        "start": "electron . --web-url=https://demo.home-assistant.io --mqtt-url=mqtt://172.0.0.1:1883 --mqtt-user=kiosk --mqtt-password=kiosk --display-type=HDMI",
+        "start": "electron . --web-url=https://demo.home-assistant.io",
         "build": "electron-forge make"
     },
     "config": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "main": "index.js",
     "scripts": {
-        "start": "electron . --web-url=https://demo.home-assistant.io",
+        "start": "electron . --web-url=https://hass.sh-software.info --mqtt-url=mqtt://10.127.100.11:1883 --mqtt-user=tablets --mqtt-password=Baltimore.2014 --display-type=HDMI",
         "build": "electron-forge make"
     },
     "config": {
@@ -58,5 +58,6 @@
     },
     "dependencies": {
         "mqtt": "^5.10.3"
-    }
+    },
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/hardware.js
+++ b/src/hardware.js
@@ -31,7 +31,7 @@ const init = async (args) => {
 
   // Check supported model
   const model = getModel();
-  if (!model || !model.includes("Raspberry Pi 5")) {
+  if (!model || !model.includes("Raspberry Pi")) {
     console.warn(`Device ${model} not supported`);
     return false;
   }
@@ -44,8 +44,10 @@ const init = async (args) => {
   console.log("Memory Usage:", getMemoryUsage());
   console.log("Processor Usage:", getProcessorUsage());
   console.log("Processor Temperature:", getProcessorTemperature());
-  console.log("Display Status:", getDisplayStatus());
-  console.log("Display Brightness:", getDisplayBrightness(), "\n");
+  // Commented out for Pi 4 testing purposes as of 05.01.2025 - 17:15
+  // console.log("Display Status:", getDisplayStatus());
+  // console.log("Display Brightness:", getDisplayBrightness(), "\n");
+
 
   // Init globals
   HARDWARE.initialized = true;
@@ -64,6 +66,9 @@ const update = () => {
   if (!HARDWARE.initialized) {
     return;
   }
+  
+  // commented out for testing Pi 4 as of 05.01.2025 - 17:19
+  /*
   const path = "/sys/class/backlight/10-0045";
 
   // Display status has changed
@@ -85,6 +90,7 @@ const update = () => {
       notifier();
     });
   }
+  */
 };
 
 /**
@@ -96,8 +102,9 @@ const hardwareExists = () => {
   const files = [
     "/sys/firmware/devicetree/base/model",
     "/sys/firmware/devicetree/base/serial-number",
-    "/sys/class/backlight/10-0045/brightness",
-    "/sys/class/backlight/10-0045/bl_power",
+    // Uncommented for testing purposes as of 05.01.2025 - 16:57
+    // "/sys/class/backlight/10-0045/brightness",
+    // "/sys/class/backlight/10-0045/bl_power",
   ];
   return files.every((file) => fs.existsSync(file));
 };

--- a/src/hardware.js
+++ b/src/hardware.js
@@ -61,7 +61,7 @@ const init = async (args) => {
   HARDWARE.status = "valid";
 
   // Check for display changes
-  setInterval(update(args), 500);
+  setInterval(() => update(args), 500);
 
   return true;
 };

--- a/src/hardware.js
+++ b/src/hardware.js
@@ -23,8 +23,14 @@ const init = async (args) => {
     return false;
   }
 
+  if (args.display_type.includes("DSI")) {
+    console.log("Running in DSI mode...");
+  }
+  else if (args.display_type.includes("HDMI")) {
+    console.log("Running in HDMI mode...");
+  }
   // Check supported hardware
-  if (!hardwareExists()) {
+  if (!hardwareExists(args)) {
     console.warn("Hardware not supported");
     return false;
   }
@@ -44,17 +50,18 @@ const init = async (args) => {
   console.log("Memory Usage:", getMemoryUsage());
   console.log("Processor Usage:", getProcessorUsage());
   console.log("Processor Temperature:", getProcessorTemperature());
-  // Commented out for Pi 4 testing purposes as of 05.01.2025 - 17:15
-  // console.log("Display Status:", getDisplayStatus());
-  // console.log("Display Brightness:", getDisplayBrightness(), "\n");
 
+  if (args.display_type.includes("DSI")) {
+    console.log("Display Status:", getDisplayStatus());
+    console.log("Display Brightness:", getDisplayBrightness(), "\n");
+  }
 
   // Init globals
   HARDWARE.initialized = true;
   HARDWARE.status = "valid";
 
   // Check for display changes
-  setInterval(update, 500);
+  setInterval(update(args), 500);
 
   return true;
 };
@@ -62,13 +69,11 @@ const init = async (args) => {
 /**
  * Updates the shared hardware properties.
  */
-const update = () => {
-  if (!HARDWARE.initialized) {
+const update = (args) => {
+  if (!HARDWARE.initialized || !args.display_type.includes("DSI")) {
     return;
   }
-  
-  // commented out for testing Pi 4 as of 05.01.2025 - 17:19
-  /*
+
   const path = "/sys/class/backlight/10-0045";
 
   // Display status has changed
@@ -90,7 +95,6 @@ const update = () => {
       notifier();
     });
   }
-  */
 };
 
 /**
@@ -98,14 +102,17 @@ const update = () => {
  *
  * @returns {bool} Returns true if all files exists.
  */
-const hardwareExists = () => {
+const hardwareExists = (args) => {
+  console.log("Running hardware checks...");
   const files = [
     "/sys/firmware/devicetree/base/model",
     "/sys/firmware/devicetree/base/serial-number",
-    // Uncommented for testing purposes as of 05.01.2025 - 16:57
-    // "/sys/class/backlight/10-0045/brightness",
-    // "/sys/class/backlight/10-0045/bl_power",
   ];
+  if (args.display_type.includes("DSI")){
+    console.log("Checking for DSI hardware...")
+    files.push("/sys/class/backlight/10-0045/brightness");
+    files.push("/sys/class/backlight/10-0045/bl_power")
+  }
   return files.every((file) => fs.existsSync(file));
 };
 

--- a/src/integration.js
+++ b/src/integration.js
@@ -63,7 +63,7 @@ const init = async (args) => {
       initReboot(INTEGRATION.client);
       initRefresh(INTEGRATION.client);
       initKiosk(INTEGRATION.client);
-      initDisplay(INTEGRATION.client);
+      // initDisplay(INTEGRATION.client);  - Commented out for Pi 4 testing purposes as of 05.01.2025 - 16:59
 
       // Init client sensors
       initModel(INTEGRATION.client);
@@ -139,7 +139,7 @@ const initShutdown = (client) => {
     .on("message", (topic, message) => {
       if (topic === `${root}/execute`) {
         console.log("Shutdown system...");
-        hardware.setDisplayStatus("ON");
+        // hardware.setDisplayStatus("ON"); - Commented out for Pi 4 testing purposes as of 05.01.2025 - 16:59
         hardware.shutdownSystem();
       }
     })
@@ -168,7 +168,7 @@ const initReboot = (client) => {
     .on("message", (topic, message) => {
       if (topic === `${root}/execute`) {
         console.log("Rebooting system...");
-        hardware.setDisplayStatus("ON");
+        // hardware.setDisplayStatus("ON"); - Commented out for Pi 4 testing purposes as of 05.01.2025 - 16:59
         hardware.rebootSystem();
       }
     })
@@ -197,7 +197,7 @@ const initRefresh = (client) => {
     .on("message", (topic, message) => {
       if (topic === `${root}/execute`) {
         console.log("Refreshing webview...");
-        hardware.setDisplayStatus("ON");
+        // hardware.setDisplayStatus("ON"); - Commented out for Pi 4 testing purposes as of 05.01.2025 - 16:59
         WEBVIEW.view.webContents.reloadIgnoringCache();
       }
     })
@@ -236,7 +236,7 @@ const initKiosk = (client) => {
       if (topic === `${root}/set`) {
         const status = message.toString();
         console.log("Set Kiosk Status:", status);
-        hardware.setDisplayStatus("ON");
+        // hardware.setDisplayStatus("ON"); - Commented out for Pi 4 testing purposes as of 05.01.2025 - 16:59
         switch (status) {
           case "Framed":
             WEBVIEW.window.restore();

--- a/src/integration.js
+++ b/src/integration.js
@@ -63,8 +63,10 @@ const init = async (args) => {
       initReboot(INTEGRATION.client);
       initRefresh(INTEGRATION.client);
       initKiosk(INTEGRATION.client);
-      // initDisplay(INTEGRATION.client);  - Commented out for Pi 4 testing purposes as of 05.01.2025 - 16:59
-
+      if (args.display_type.includes("DSI")){
+        initDisplay(INTEGRATION.client);
+      }
+      
       // Init client sensors
       initModel(INTEGRATION.client);
       initSerialNumber(INTEGRATION.client);
@@ -139,7 +141,7 @@ const initShutdown = (client) => {
     .on("message", (topic, message) => {
       if (topic === `${root}/execute`) {
         console.log("Shutdown system...");
-        // hardware.setDisplayStatus("ON"); - Commented out for Pi 4 testing purposes as of 05.01.2025 - 16:59
+        hardware.setDisplayStatus("ON");
         hardware.shutdownSystem();
       }
     })
@@ -168,7 +170,7 @@ const initReboot = (client) => {
     .on("message", (topic, message) => {
       if (topic === `${root}/execute`) {
         console.log("Rebooting system...");
-        // hardware.setDisplayStatus("ON"); - Commented out for Pi 4 testing purposes as of 05.01.2025 - 16:59
+        hardware.setDisplayStatus("ON");
         hardware.rebootSystem();
       }
     })
@@ -197,7 +199,7 @@ const initRefresh = (client) => {
     .on("message", (topic, message) => {
       if (topic === `${root}/execute`) {
         console.log("Refreshing webview...");
-        // hardware.setDisplayStatus("ON"); - Commented out for Pi 4 testing purposes as of 05.01.2025 - 16:59
+        hardware.setDisplayStatus("ON");
         WEBVIEW.view.webContents.reloadIgnoringCache();
       }
     })
@@ -236,7 +238,7 @@ const initKiosk = (client) => {
       if (topic === `${root}/set`) {
         const status = message.toString();
         console.log("Set Kiosk Status:", status);
-        // hardware.setDisplayStatus("ON"); - Commented out for Pi 4 testing purposes as of 05.01.2025 - 16:59
+        hardware.setDisplayStatus("ON");
         switch (status) {
           case "Framed":
             WEBVIEW.window.restore();


### PR DESCRIPTION
The changes in this PR include an additional argument to set the display type. Allowed values are HDMI and DSI to differentiate between those types of Display.

Setting the argument to HDMI disables the display and brightness control/values as they are not available via HDMI. DSI enables full functionality.

Also, since this is the only reason functionality was limited to the Pi 5 in the first place, I removed the restriction and allowed all Pi models.

Please feel free to check my changes and propose any enhancements.