### PR TITLE
Fix for URL containing query params

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ const parseArgs = (proc) => {
   let args = {};
   proc.argv.slice(1).forEach((arg) => {
     if (arg !== ".") {
-      const [key, value] = arg.split("=");
+      const [key, value] = /^(.*?)=(.*)$/.exec(arg).slice(1);
       args[key.replace("--", "").replace("-", "_")] = value;
     }
   });


### PR DESCRIPTION
The current way of parsing the arguments breaks URLs containing query params: `--web-url=https://example.com?param=value` gets parsed as `web_url: 'https://example.com?param'`, since the split function splits on all `=` characters, not just the first.

This fixes that. There are probably a million different ways to do this, but the regex seems like the easiest solution right now. 