### PR TITLE
Make Webview Zoom Changeable from Home Assistant

### DIFF
--- a/js/integration.js
+++ b/js/integration.js
@@ -473,7 +473,7 @@ const initPageZoom = () => {
     icon: "mdi:magnify-plus-outline",
     device: INTEGRATION.device,
   };
-  publishConfig("zoom", config)
+  publishConfig("number", config)
     .on("message", (topic, message) => {
       if (topic === config.command_topic) {
         const zoom = parseInt(message, 10);

--- a/js/integration.js
+++ b/js/integration.js
@@ -67,6 +67,7 @@ const init = async () => {
       initDisplay();
       initKeyboard();
       initPageNumber();
+      initPageZoom();
       initPageUrl();
 
       // Init client sensors
@@ -130,6 +131,7 @@ const update = async () => {
   // Update client sensors
   updateKiosk();
   updatePageNumber();
+  updatePageZoom();
   updatePageUrl();
   updateUpTime();
   updateLastActive();
@@ -451,6 +453,44 @@ const initPageNumber = () => {
 const updatePageNumber = () => {
   const pageNumber = WEBVIEW.viewActive;
   publishState("page_number", pageNumber);
+};
+
+/**
+ * Initializes the page zoom and handles the execute logic.
+ */
+const initPageZoom = () => {
+  const root = `${INTEGRATION.root}/page_zoom`;
+  const config = {
+    name: "Page Zoom",
+    unique_id: `${INTEGRATION.node}_page_zoom`,
+    command_topic: `${root}/set`,
+    state_topic: `${root}/state`,
+    value_template: "{{ value | int }}",
+    mode: "slider",
+    min: 10,
+    max: 400,
+    unit_of_measurement: "%",
+    icon: "mdi:magnify-plus-outline",
+    device: INTEGRATION.device,
+  };
+  publishConfig("zoom", config)
+    .on("message", (topic, message) => {
+      if (topic === config.command_topic) {
+        const zoom = parseInt(message, 10);
+        console.log("Set Page Zoom:", zoom);
+        WEBVIEW.viewZoom = zoom / 100.0;
+      }
+    })
+    .subscribe(config.command_topic);
+  updatePageZoom();
+};
+
+/**
+ * Updates the page zoom via the mqtt connection.
+ */
+const updatePageZoom = () => {
+  const pageZoom = Math.round(WEBVIEW.viewZoom * 100.0);
+  publishState("page_zoom", pageZoom);
 };
 
 /**

--- a/js/webview.js
+++ b/js/webview.js
@@ -38,7 +38,15 @@ const init = async () => {
 
   // Init global properties
   WEBVIEW.viewUrls = urls;
-  WEBVIEW.viewZoom = zoom;
+  Object.defineProperty(WEBVIEW, "viewZoom", {
+    get() {
+      return this._viewZoom || zoom;
+    },
+    set(v) {
+      this._viewZoom = Math.max(0, v);
+      updateZoom();
+    },
+  });
   WEBVIEW.viewTheme = theme;
   WEBVIEW.widgetTheme = theme;
   WEBVIEW.widgetEnabled = widget;
@@ -313,6 +321,17 @@ const resizeView = () => {
     });
     WEBVIEW.navigation.webContents.send("data-theme", { theme: WEBVIEW.navigationTheme });
   }
+};
+
+/**
+ * Updates zoom level for all webviews.
+ */
+const updateZoom = () => {
+  // And apply to all views
+  WEBVIEW.views.forEach((view) => {
+    view.webContents.setZoomFactor(WEBVIEW.viewZoom);
+  });
+
 };
 
 /**


### PR DESCRIPTION
Add a new MQTT parameter `view_zoom` that allows changing the zoom level of the webviews. This is related to #48.

The MQTT value has been configured to be given as a percentage (%) which is then converted to the desired web views scale factor. I've also set it to be displayed in HA as a slider, with limits of 10% to 400% - picked pretty arbitrarily, feel free to change.

I've tested this now and it appears to be largely functional. Changing the slider updates the view zoom level in real time.

At the moment the zoom level beside the slider only updates once every MQTT update interval, this could perhaps be improved by having it return the value whenever changed, but given all the other parameters seem to stick to the update interval, I've followed suit.

<img width="1555" height="590" alt="image" src="https://github.com/user-attachments/assets/ac78a181-0e92-4b36-9071-3b5c70413aae" />

<img width="1567" height="597" alt="image" src="https://github.com/user-attachments/assets/33b55123-4770-4f98-b1d2-9a5badd48f11" />
