### PR TITLE
add armhf arch, eg raspi2 32bit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,4 +27,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          yarn electron-forge publish --arch arm64,x64
+          yarn electron-forge publish --arch arm64,x64,armv7l

--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -19,6 +19,7 @@ If you are running Linux with a graphical user interface (Wayland or X11), you s
 ### DSI
 | Device                 | System                                 | Display                                                                                                   | Status |
 | ---------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------ |
+| Raspberry Pi 2 (armhf) | Raspberry Pi OS (32-bit), Wayland, X11 | [Official 7" Touch Display 1 (800x480)](https://www.raspberrypi.com/products/raspberry-pi-touch-display/) | ⬜      |
 | Raspberry Pi 3 (arm64) | Raspberry Pi OS (64-bit), Wayland, X11 | [Official 7" Touch Display 1 (800x480)](https://www.raspberrypi.com/products/raspberry-pi-touch-display/) | ⬜      |
 | Raspberry Pi 3 (arm64) | Raspberry Pi OS (64-bit), Wayland, X11 | [Official 7" Touch Display 2 (720x1280)](https://www.raspberrypi.com/products/touch-display-2/)           | ⬜      |
 | Raspberry Pi 4 (arm64) | Raspberry Pi OS (64-bit), Wayland, X11 | [Official 7" Touch Display 1 (800x480)](https://www.raspberrypi.com/products/raspberry-pi-touch-display/) | 🟩      |

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Additionally, a **MQTT endpoint** can be defined, allowing the application to pr
 
 ## Setup
 Before you begin, make sure that you have a Linux device configured and operational with a [compatible](https://github.com/leukipp/touchkio/blob/main/HARDWARE.md) Touch Display.
-This guide assumes that you are using a Raspberry Pi with the latest version of Raspberry Pi OS **(64-bit)**, along with a desktop environment (preferred using **labwc**).
-However, the **.deb** setup procedure is also compatible with any other Debian based 64-bit system.
+This guide assumes that you are using a Raspberry Pi with the latest version of Raspberry Pi OS, along with a desktop environment (preferred using **labwc**).
+However, the **.deb** setup procedure is also compatible with any other Debian based 64-bit or 32-bit system.
 
 ### Optional
 To utilize the sensor features of your device through Home Assistant, it's essential to have a **MQTT broker running** and the **MQTT integration installed** on your Home Assistant instance.
@@ -50,7 +50,7 @@ You might also need a physical keyboard or remote VNC access to input these cred
 If your hardware is [supported](https://github.com/leukipp/touchkio/blob/main/HARDWARE.md) you may be able to activate the on-screen keyboard using the side [widget](https://github.com/leukipp/touchkio/issues/16).
 
 #### Option 1 - The easy way
-Run this command to download and install the latest **.deb** (arm64 or x64) release.
+Run this command to download and install the latest **.deb** (arm64, armhf or x64) release.
 It will also create a systemd user file for auto-startup and will guide you through the setup process:
 ```bash
 bash <(wget -qO- https://raw.githubusercontent.com/leukipp/touchkio/main/install.sh)
@@ -69,7 +69,7 @@ systemctl --user start|stop|status|restart touchkio.service
 #### Option 2 - The standard way
 When connected via SSH, it's necessary to export the display variables first, as outlined in the [development](https://github.com/leukipp/touchkio?tab=readme-ov-file#development) section.
 The [install.sh](https://github.com/leukipp/touchkio/blob/main/install.sh) script mentioned above performs the following tasks (and you just have to do it manually):
-- [Download](https://github.com/leukipp/touchkio/releases/latest) the latest version file that is suitable for your architecture (arm64 or x64).
+- [Download](https://github.com/leukipp/touchkio/releases/latest) the latest version file that is suitable for your architecture (arm64, armhf or x64).
   - Debian (**deb**): Open a terminal and execute the following command to install the application, e.g:
 `sudo apt install ./touchkio_1.x.x_arm64.deb && touchkio --setup`
   - Others (**zip**): Extract the archive and run the binary, e.g:  `unzip touchkio-linux-x64-1.x.x.zip && cd touchkio-linux-x64 && ./touchkio --setup`
@@ -79,7 +79,7 @@ The [install.sh](https://github.com/leukipp/touchkio/blob/main/install.sh) scrip
 - If you need the application to be automatically started on boot, create a systemd file.
 
 #### Option 3 - The hard way
-Pre-built release files are available for arm64 and x64 Linux systems.
+Pre-built release files are available for arm64, armhf and x64 Linux systems.
 If you are using a different architecture, you can still utilize this repository to build your own application.
 
 For more information please refer to the [development](https://github.com/leukipp/touchkio?tab=readme-ov-file#development) section, however this will do the job:

--- a/install.sh
+++ b/install.sh
@@ -19,12 +19,14 @@ case "$(uname -m)" in
     x86_64)
         ARCH="x64"
         ;;
+    armv7l|armv6l|armv8l)
+        ARCH="armhf"
+        ;;
     *)
         { echo "Architecture $(uname -m) running $BITS-bit operating system is not supported."; exit 1; }
         ;;
 esac
 
-[ "$BITS" -eq 64 ] || { echo "Architecture $ARCH running $BITS-bit operating system is not supported."; exit 1; }
 echo "Architecture $ARCH running $BITS-bit operating system is supported."
 
 # Download the latest .deb package


### PR DESCRIPTION
Was it a deliberate choice to not build for 32-bit?
I am running touchkio on a Raspberry Pi 2 (32bit) with the Official 7" Touch Display 1 just fine. 

Speed and responsiveness are not superb but manageable. The speed is the reason why i marked it as ⬜ in the docs despite everything else working as intended (for me).

this pr includes respective changes for:
* gh Actions
* install.sh
* docs