### PR TITLE
fix: Multitouch mode not working properly

### DIFF
--- a/js/integration.js
+++ b/js/integration.js
@@ -153,7 +153,6 @@ const init = async () => {
   }, 3600 * 1000);
 
   // Cleanup motion timer on app exit
-  const { app } = require("electron");
   app.on("before-quit", () => {
     if (WEBVIEW.tracker.motion.clearTimer) {
       clearTimeout(WEBVIEW.tracker.motion.clearTimer);

--- a/js/webview.js
+++ b/js/webview.js
@@ -1305,7 +1305,7 @@ const appEvents = async () => {
     } else if (!shouldBlock && WEBVIEW.inputBlocking.enabled) {
       unblockAllInput();
     }
-  }, 100);
+  }, 500);
 
   // Handle global events
   EVENTS.on("reloadView", reloadView);

--- a/js/webview.js
+++ b/js/webview.js
@@ -1317,6 +1317,8 @@ const appEvents = async () => {
       if (status === "OFF") {
         blockAllInput();
       }
+    } else {
+      console.warn("webview.js: Failed to retrieve display status");
     }
   });
   EVENTS.on("updateStatus", () => {


### PR DESCRIPTION
In light of multitouch mode not working to wake the display and block touches while display is off, I crafted a new method of blocking input and waking the display. Input is now blocked using a more reliable Javascript method that works with both mouse emulation mode and multitouch mode. This may also be able to close #148. If this is accepted, [`HARDWARE.md`](../blob/main/HARDWARE.md) may need to be updated.

# Changes
- Removed current code that blocked touches when display is off and tried to turn on display on touch.
- Implemented javascript to block touches when display is off, and continues to block for 500ms after display turns on to avoid accidental touches.
- Confirmed this method still works in mouse emulation mode.
### New features (just a cherry on-top)
- Added a nice-to-have motion sensor to MQTT, idea taken from [`browser_mod 2`](https://github.com/thomasloven/hass-browser_mod)