### PR TITLE
Update webview.js

### DIFF
--- a/js/webview.js
+++ b/js/webview.js
@@ -1173,6 +1173,7 @@ const viewEvents = async () => {
 
                 // Turn display on if it was off
                 hardware.setDisplayStatus("ON");
+                WEBVIEW.tracker.display.on = new Date();
               }
               break;
             case "back":


### PR DESCRIPTION
The timestamp tracker.display.on is only updated when the updateDisplay event is emitted. In hardware.js, this event is emitted by the update() function which polls sysfs every second. The problem:

a. Screen OFF → tracker.display.off = Date
b. Touch → setDisplayStatus("ON") called (async, wlopm starts) 
c. Next touch arrives < 1 second later
d. Polling hasn't detected the change yet → updateDisplay not yet emitted 
e. Tracker.display.on not updated → off > on remains true 
f. Touch ignored until next successfull off/on cycle