### PR TITLE
feat: add ambient light sensor (illuminance) support

### DIFF
--- a/js/hardware.js
+++ b/js/hardware.js
@@ -13,6 +13,9 @@ global.HARDWARE = global.HARDWARE || {
       path: null,
     },
   },
+  illuminance: {
+    path: null,
+  },
   display: {
     status: {
       path: null,
@@ -49,6 +52,7 @@ const init = async () => {
   HARDWARE.session.type = sessionType();
   HARDWARE.session.desktop = sessionDesktop();
   HARDWARE.battery.level.path = getBatteryLevelPath();
+  HARDWARE.illuminance.path = getIlluminancePath();
   HARDWARE.display.status.path = getDisplayStatusPath();
   HARDWARE.display.status.command = getDisplayStatusCommand();
   HARDWARE.display.brightness.path = getDisplayBrightnessPath();
@@ -92,6 +96,12 @@ const init = async () => {
   console.info(
     `Battery Level [${HARDWARE.support.batteryLevel ? HARDWARE.battery.level.path : unsupported}]:`,
     batteryLevelInfo,
+  );
+  const illuminance = `${getIlluminance()} (sysfs)`;
+  const illuminanceInfo = HARDWARE.support.illuminance ? illuminance : unsupported;
+  console.info(
+    `Illuminance [${HARDWARE.support.illuminance ? HARDWARE.illuminance.path : unsupported}]:`,
+    illuminanceInfo,
   );
   const displayStatus = `${getDisplayStatus()} (${HARDWARE.display.status.command})`;
   const displayStatusInfo = HARDWARE.support.displayStatus ? displayStatus : unsupported;
@@ -293,6 +303,7 @@ const checkSupport = () => {
 
   const audioDevice = !!HARDWARE.audio.device;
   const batteryPath = !!HARDWARE.battery.level.path;
+  const illuminancePath = !!HARDWARE.illuminance.path;
   const statusPath = !!HARDWARE.display.status.path;
   const statusCommand = !!HARDWARE.display.status.command;
   const brightnessPath = !!HARDWARE.display.brightness.path && !!HARDWARE.display.brightness.value.max;
@@ -300,6 +311,7 @@ const checkSupport = () => {
 
   return {
     batteryLevel: batteryPath,
+    illuminance: illuminancePath,
     displayStatus: statusPath && statusCommand,
     displayBrightness: sudo && statusPath && statusCommand && (brightnessPath || brightnessCommand),
     keyboardVisibility: keyboard,
@@ -497,6 +509,46 @@ const getBatteryLevel = () => {
   const capacity = readFile(`${HARDWARE.battery.level.path}/capacity`);
   if (capacity) {
     return parseFloat(capacity);
+  }
+  return null;
+};
+
+/**
+ * Gets the ambient light sensor path using `/sys/bus/iio/devices`.
+ *
+ * @returns {string|null} The illuminance sensor path or null if nothing was found.
+ */
+const getIlluminancePath = () => {
+  const iio = "/sys/bus/iio/devices";
+  if (!fs.existsSync(iio)) {
+    return null;
+  }
+  for (const device of fs.readdirSync(iio)) {
+    const nameFile = path.join(iio, device, "name");
+    const rawFile = path.join(iio, device, "in_illuminance_raw");
+    if (!fs.existsSync(nameFile) || !fs.existsSync(rawFile)) {
+      continue;
+    }
+    const name = readFile(nameFile);
+    if (name === "als") {
+      return path.join(iio, device);
+    }
+  }
+  return null;
+};
+
+/**
+ * Gets the current ambient light level in lux using `/sys/bus/iio/devices/.../in_illuminance_raw`.
+ *
+ * @returns {number|null} The illuminance in lux or null if nothing was found.
+ */
+const getIlluminance = () => {
+  if (!HARDWARE.support.illuminance) {
+    return null;
+  }
+  const raw = readFile(`${HARDWARE.illuminance.path}/in_illuminance_raw`);
+  if (raw) {
+    return parseFloat(raw);
   }
   return null;
 };
@@ -1204,6 +1256,7 @@ module.exports = {
   getProcessorUsage,
   getProcessorTemperature,
   getBatteryLevel,
+  getIlluminance,
   getDisplayStatus,
   setDisplayStatus,
   getDisplayBrightness,

--- a/js/integration.js
+++ b/js/integration.js
@@ -89,6 +89,7 @@ const init = async () => {
       initProcessorUsage();
       initProcessorTemperature();
       initBatteryLevel();
+      initIlluminance();
       initPackageUpgrades();
       initLastActive();
 
@@ -179,6 +180,7 @@ const update = async () => {
   updateProcessorUsage();
   updateProcessorTemperature();
   updateBatteryLevel();
+  updateIlluminance();
 };
 
 /**
@@ -995,6 +997,37 @@ const initBatteryLevel = () => {
 const updateBatteryLevel = async () => {
   const batteryLevel = hardware.getBatteryLevel();
   publishState("battery_level", batteryLevel);
+};
+
+/**
+ * Initializes the illuminance sensor.
+ */
+const initIlluminance = () => {
+  const root = `${INTEGRATION.root}/illuminance`;
+  const config = {
+    name: "Illuminance",
+    unique_id: `${INTEGRATION.node}_illuminance`,
+    state_topic: `${root}/state`,
+    value_template: "{{ (value | float) | round(0) }}",
+    unit_of_measurement: "lx",
+    device_class: "illuminance",
+    icon: "mdi:brightness-5",
+    device: INTEGRATION.device,
+  };
+  if (!HARDWARE.support.illuminance) {
+    removeConfig("sensor", config);
+    return;
+  }
+  publishConfig("sensor", config);
+  updateIlluminance();
+};
+
+/**
+ * Updates the illuminance sensor via the mqtt connection.
+ */
+const updateIlluminance = async () => {
+  const illuminance = hardware.getIlluminance();
+  publishState("illuminance", illuminance);
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds support for reading ambient light level (illuminance) from Linux IIO ALS devices via sysfs (`/sys/bus/iio/devices/*/in_illuminance_raw`)
- Exposes an illuminance sensor (lux) through MQTT with Home Assistant auto-discovery (`device_class: illuminance`)
- Devices without an ALS gracefully skip the sensor via `removeConfig`

## Implementation
- **hardware.js**: `getIlluminancePath()` scans IIO devices for one named `als` with `in_illuminance_raw`, `getIlluminance()` reads the raw lux value, `illuminance` added to `checkSupport()`
- **integration.js**: `initIlluminance()` / `updateIlluminance()` following the existing sensor pattern, updated in the 1-minute periodic cycle

## Testing
Tested on:
- **Surface Pro 3** (HID-SENSOR-200041 via `hid-sensor-als` driver) — working, reports lux values
- **Surface 3** (same driver, dead hardware) — gracefully detects ALS support but sensor returns 0; `removeConfig` would apply on devices with no IIO ALS at all

## Notes
The IIO ambient light sensor is commonly available on tablets and laptops with HID sensor hubs (Surface devices, ThinkPads, etc.). The sensor name `als` is the standard name used by the `hid-sensor-als` kernel driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)