### PR TITLE
fix: prioritize reliable thermal sensors over acpitz

### DIFF
--- a/js/hardware.js
+++ b/js/hardware.js
@@ -451,6 +451,8 @@ const getProcessorUsage = () => {
  */
 const getProcessorTemperature = () => {
   const thermal = "/sys/class/thermal";
+  const priorities = ["x86_pkg_temp", "k10temp", "cpu-thermal", "soc_dts0", "PNIT", "cpu", "acpitz"];
+  let best = null;
   for (const zone of fs.readdirSync(thermal)) {
     const typeFile = path.join(thermal, zone, "type");
     const tempFile = path.join(thermal, zone, "temp");
@@ -458,14 +460,20 @@ const getProcessorTemperature = () => {
       continue;
     }
     const type = readFile(typeFile);
-    if (["cpu-thermal", "x86_pkg_temp", "k10temp", "acpitz", "cpu"].includes(type)) {
+    const priority = priorities.indexOf(type);
+    if (priority !== -1) {
       const temp = readFile(tempFile);
       if (temp) {
-        return parseFloat(temp) / 1000;
+        const celsius = parseFloat(temp) / 1000;
+        if (celsius >= -40 && celsius <= 150) {
+          if (best === null || priority < priorities.indexOf(best.type)) {
+            best = { type, celsius };
+          }
+        }
       }
     }
   }
-  return null;
+  return best ? best.celsius : null;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Prioritize more reliable thermal sensors (`x86_pkg_temp`, `k10temp`, `cpu-thermal`) over `acpitz`
- Filter out obviously invalid temperature readings (outside -40°C to 150°C range)

## Problem
`getProcessorTemperature()` returns the first matching thermal zone, which on some hardware (e.g. Surface Pro 3) is `acpitz` reporting **-269°C**. Meanwhile `x86_pkg_temp` on the same device correctly reports ~46°C.

```
$ for zone in /sys/class/thermal/thermal_zone*; do
    echo "$(cat $zone/type): $(cat $zone/temp)"
  done
acpitz: -268800
x86_pkg_temp: 46000
```

## Fix
Instead of returning the first match, iterate all zones and select the one with the highest priority. `acpitz` is kept as a last-resort fallback but only if its value is within a sane range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)