### PR TITLE
fix: expose display brightness without display status command

### DIFF
--- a/js/hardware.js
+++ b/js/hardware.js
@@ -298,10 +298,13 @@ const checkSupport = () => {
   const brightnessPath = !!HARDWARE.display.brightness.path && !!HARDWARE.display.brightness.value.max;
   const brightnessCommand = !!HARDWARE.display.brightness.command && !!HARDWARE.display.brightness.value.max;
 
+  const hasBrightness = sudo && (brightnessPath || brightnessCommand);
+
   return {
     batteryLevel: batteryPath,
-    displayStatus: statusPath && statusCommand,
-    displayBrightness: sudo && statusPath && statusCommand && (brightnessPath || brightnessCommand),
+    // Assume displayStatus is true if brightness works but status command doesn't (e.g., cage)
+    displayStatus: (statusPath && statusCommand) || hasBrightness,
+    displayBrightness: hasBrightness,
     keyboardVisibility: keyboard,
     audioVolume: audioDevice,
     sudoRights: sudo,
@@ -576,6 +579,10 @@ const getDisplayStatus = () => {
       }
       break;
   }
+  // If no status command but brightness is supported, assume display is on
+  if (HARDWARE.support.displayBrightness) {
+    return "ON";
+  }
   return null;
 };
 
@@ -607,6 +614,10 @@ const setDisplayStatus = (status, callback = null) => {
       break;
     case "xset":
       execAsyncCommand("xset", ["dpms", "force", status.toLowerCase()], callback);
+      break;
+    default:
+      // No display status command available, just call callback
+      if (typeof callback === "function") callback(null, null);
       break;
   }
 };


### PR DESCRIPTION
## Summary
- Decouple `displayBrightness` from requiring a display status command (`wlopm`/`kscreen-doctor`/`xset`)
- Allow sysfs backlight and ddcutil brightness control in kiosk sessions (e.g., Cage) where no DPMS command is available

## Problem
In Cage wayland sessions (common for kiosks), none of `wlopm`, `kscreen-doctor`, or `xset` are available. The `checkSupport()` function required `statusCommand` for `displayBrightness`, so the display light entity was removed from Home Assistant even though sysfs brightness (`/sys/class/backlight/*/brightness`) works fine.

```
Supported: {
  "displayStatus": false,
  "displayBrightness": false,  ← should be true
  ...
}
```

## Fix
- `displayBrightness` now only requires `sudo` and a brightness path/command, independent of display status
- `displayStatus` is inferred as `true` when brightness works (if you can control brightness, the display is on)
- `getDisplayStatus()` returns `"ON"` as fallback when brightness is supported but no status command exists
- `setDisplayStatus()` calls the callback in the default case so the init chain completes

## Testing
Tested on Surface Pro 3 running TouchKio v1.4.2 in a Cage wayland session. After the fix, the display light entity appears in Home Assistant with brightness control (1-100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)