### PR TITLE
feat: Add DDC power mode (VCP 0xD6) support for HDMI display on/off

### DIFF
--- a/js/hardware.js
+++ b/js/hardware.js
@@ -17,6 +17,7 @@ global.HARDWARE = global.HARDWARE || {
     status: {
       path: null,
       command: null,
+      ddcPowerMode: false,
       value: {},
     },
     brightness: {
@@ -50,10 +51,10 @@ const init = async () => {
   HARDWARE.session.desktop = sessionDesktop();
   HARDWARE.battery.level.path = getBatteryLevelPath();
   HARDWARE.display.status.path = getDisplayStatusPath();
-  HARDWARE.display.status.command = getDisplayStatusCommand();
   HARDWARE.display.brightness.path = getDisplayBrightnessPath();
   HARDWARE.display.brightness.command = getDisplayBrightnessCommand();
   HARDWARE.display.brightness.value.max = getDisplayBrightnessMax();
+  HARDWARE.display.status.command = getDisplayStatusCommand();
   HARDWARE.audio.device = getAudioDevice();
   HARDWARE.support = checkSupport();
   HARDWARE.initialized = true;
@@ -96,7 +97,7 @@ const init = async () => {
   const displayStatus = `${getDisplayStatus()} (${HARDWARE.display.status.command})`;
   const displayStatusInfo = HARDWARE.support.displayStatus ? displayStatus : unsupported;
   console.info(
-    `Display Status [${HARDWARE.support.displayStatus ? HARDWARE.display.status.path : unsupported}]:`,
+    `Display Status [${HARDWARE.support.displayStatus ? (HARDWARE.display.status.command === "ddcutil" ? "ddc://vcp/feature/0xD6" : HARDWARE.display.status.path) : unsupported}]:`,
     displayStatusInfo,
   );
   const displayBrightness = `${getDisplayBrightness()} (${HARDWARE.display.brightness.command || "sysfs"})`;
@@ -168,6 +169,16 @@ const update = async () => {
   // Check if display status has changed
   if (HARDWARE.support.displayStatus) {
     let displayStatusChanged = false;
+
+    // Use cache status path if available (ddcutil)
+    if (HARDWARE.display.status.command === "ddcutil") {
+      const status = await readFile(path.join(APP.cache, "Status.vcp"), false);
+      const statusChanged = !!status && status !== HARDWARE.display.status.value.status;
+
+      // Update internal status values
+      HARDWARE.display.status.value.status = status;
+      displayStatusChanged |= statusChanged;
+    }
 
     // Use sysfs dpms path if available
     if (HARDWARE.display.status.path) {
@@ -527,6 +538,12 @@ const getDisplayStatusPath = () => {
  * @returns {string|null} The display status command or null if nothing was found.
  */
 const getDisplayStatusCommand = () => {
+  // Prefer ddcutil when already used for brightness (HDMI without sysfs backlight)
+  if (HARDWARE.display.brightness.command === "ddcutil" && HARDWARE.display.status.ddcPowerMode) {
+    fs.writeFileSync(path.join(APP.cache, "Status.vcp"), "");
+    return "ddcutil";
+  }
+
   const type = HARDWARE.session.type;
   const desktop = HARDWARE.session.desktop;
   const mapping = {
@@ -541,6 +558,13 @@ const getDisplayStatusCommand = () => {
       return map.command;
     }
   }
+
+  // Fallback to ddcutil DDC power mode (VCP 0xD6) when no DPMS tool is available
+  if (HARDWARE.display.status.ddcPowerMode) {
+    fs.writeFileSync(path.join(APP.cache, "Status.vcp"), "");
+    return "ddcutil";
+  }
+
   return null;
 };
 
@@ -575,6 +599,13 @@ const getDisplayStatus = () => {
         return output ? "ON" : "OFF";
       }
       break;
+    case "ddcutil":
+      const ddc = execSyncCommand("sudo", ["ddcutil", "getvcp", "d6", "--brief"]);
+      if (ddc !== null) {
+        const match = ddc.match(/x0([14])/);
+        if (match) return match[1] === "1" ? "ON" : "OFF";
+      }
+      break;
   }
   return null;
 };
@@ -607,6 +638,14 @@ const setDisplayStatus = (status, callback = null) => {
       break;
     case "xset":
       execAsyncCommand("xset", ["dpms", "force", status.toLowerCase()], callback);
+      break;
+    case "ddcutil":
+      execAsyncCommand("sudo", ["ddcutil", "setvcp", "--noverify", "d6", status === "ON" ? "1" : "4"], (reply, error) => {
+        if (!error) {
+          fs.writeFileSync(path.join(APP.cache, "Status.vcp"), status);
+        }
+        if (typeof callback === "function") callback(reply, error);
+      });
       break;
   }
 };
@@ -646,9 +685,12 @@ const getDisplayBrightnessCommand = () => {
       switch (map.command) {
         case "ddcutil":
           const output = execSyncCommand("sudo", ["ddcutil", "capabilities"]);
-          if (output && output.includes("Feature: 10")) {
-            fs.writeFileSync(path.join(APP.cache, "Brightness.vcp"), "");
-            return map.command;
+          if (output) {
+            HARDWARE.display.status.ddcPowerMode = output.includes("Feature: D6");
+            if (output.includes("Feature: 10")) {
+              fs.writeFileSync(path.join(APP.cache, "Brightness.vcp"), "");
+              return map.command;
+            }
           }
           break;
         default:


### PR DESCRIPTION
## Summary

- Adds `ddcutil setvcp/getvcp 0xD6` as a display status command for HDMI touchscreens that support DDC/CI power mode control
- Preferred over DPMS when ddcutil is already used for brightness (no sysfs backlight — the exact scenario where DPMS shows "No signal" instead of turning off the panel)
- Falls back to ddcutil when no DPMS tool (wlopm/kscreen-doctor/xset) is available but the display supports VCP feature D6

### Problem

On HDMI-connected touchscreens without a sysfs backlight, the existing DPMS-based display on/off (wlopm/kscreen-doctor/xset) kills the HDMI signal rather than turning the panel off. The monitor shows "No signal" instead of actually powering down. TouchKio already uses `ddcutil` for brightness control on these screens — the same infrastructure can control power mode.

### Solution

DDC/CI VCP feature `0xD6` (Power mode) properly turns HDMI panels off (`0x04`) and on (`0x01`) without losing the HDMI link. This PR:

1. **Detects D6 support** during `getDisplayBrightnessCommand()` init (which already calls `ddcutil capabilities`), storing the result in `HARDWARE.display.status.ddcPowerMode`
2. **Selects ddcutil as the status command** when:
   - ddcutil is already used for brightness AND D6 is supported (preferred), or
   - No DPMS tool is available AND D6 is supported (fallback)
3. **Gets display status** via `ddcutil getvcp d6 --brief` (parses `x01`=ON, `x04`=OFF)
4. **Sets display status** via `ddcutil setvcp --noverify d6 <value>` with cache file tracking
5. **Polls status changes** via a `Status.vcp` cache file (same pattern as `Brightness.vcp`) to avoid slow ddcutil polling in the 1s update loop

### Note on `--noverify`

The `--noverify` flag is required because many monitors return a DDC verification error on power-on even though the command succeeds. This is a well-known ddcutil behaviour (see [ddcutil#36](https://github.com/rockowitz/ddcutil/issues/36)). Without it, successful power commands would be reported as failures.

### Init reorder

Brightness detection is moved before status command detection in `init()` because `getDisplayStatusCommand()` now checks whether ddcutil is already being used for brightness to decide whether to prefer DDC power mode over DPMS.

Closes #187

## Test plan

- [ ] Verify `Supported: {...}` output at startup shows `displayStatus: true` on an HDMI touchscreen with ddcutil and D6 support
- [ ] Verify startup log shows `Display Status [ddc://vcp/feature/0xD6]: ON (ddcutil)`
- [ ] Send "OFF" via MQTT (`light.turn_off`) → screen turns off properly (no "No signal")
- [ ] Send "ON" via MQTT (`light.turn_on`) → screen turns back on
- [ ] Verify `getDisplayStatus()` correctly reports ON/OFF based on `ddcutil getvcp d6`
- [ ] Verify brightness control continues to work independently
- [ ] Verify existing DPMS setups (wlopm/kscreen-doctor/xset) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)