### PR TITLE
fix: save and restore brightness on display OFF/ON for sysfs backlight displays

### DIFF
--- a/js/hardware.js
+++ b/js/hardware.js
@@ -609,6 +609,16 @@ const setDisplayStatus = (status, callback = null) => {
       execAsyncCommand("xset", ["dpms", "force", status.toLowerCase()], callback);
       break;
   }
+  if (HARDWARE.support.displayBrightness && !HARDWARE.display.brightness.command) {
+    if (status === "OFF") {
+      HARDWARE.display.brightness.value.saved = getDisplayBrightness();
+      setDisplayBrightness(0);
+    } else if (status === "ON" && HARDWARE.display.brightness.value.saved != null) {
+      const saved = HARDWARE.display.brightness.value.saved;
+      HARDWARE.display.brightness.value.saved = null;
+      setDisplayBrightness(saved);
+    }
+  }
 };
 
 /**
@@ -725,8 +735,8 @@ const setDisplayBrightness = (brightness, callback = null) => {
     if (typeof callback === "function") callback(null, "Not supported");
     return;
   }
-  if (typeof brightness !== "number" || brightness < 1 || brightness > 100) {
-    console.error("Brightness must be a number between 1 and 100");
+  if (typeof brightness !== "number" || brightness < 0 || brightness > 100) {
+    console.error("Brightness must be a number between 0 and 100");
     if (typeof callback === "function") callback(null, "Invalid brightness");
     return;
   }
@@ -742,7 +752,7 @@ const setDisplayBrightness = (brightness, callback = null) => {
   }
   if (HARDWARE.display.brightness.path) {
     const max = HARDWARE.display.brightness.value.max || 1;
-    const value = Math.max(1, Math.min(Math.round((brightness / 100) * max), max));
+    const value = Math.max(0, Math.min(Math.round((brightness / 100) * max), max));
     const proc = execAsyncCommand("sudo", ["tee", path.join(HARDWARE.display.brightness.path, "brightness")], callback);
     proc.stdin.write(value.toString());
     proc.stdin.end();

--- a/js/hardware.js
+++ b/js/hardware.js
@@ -715,7 +715,7 @@ const getDisplayBrightness = () => {
     const brightness = readFile(path.join(HARDWARE.display.brightness.path, "brightness"));
     if (brightness) {
       const max = HARDWARE.display.brightness.value.max || 1;
-      return Math.max(1, Math.min(Math.round((parseInt(brightness, 10) / max) * 100), 100));
+      return Math.max(0, Math.min(Math.round((parseInt(brightness, 10) / max) * 100), 100));
     }
   }
   return null;


### PR DESCRIPTION
On displays using PWM backlight controlled via sysfs (/sys/class/backlight), turning the display OFF via the HDMI signal alone is not enough to physically turn off the screen because the backlight stays on. Setting brightness to 0 is required to actually turn it off.

Previously the minimum allowed brightness was hardcoded to 1, both in the validation and in the sysfs write clamp, making it impossible to reach 0.

Changes:

- setDisplayBrightness(): allow 0 as a valid brightness value (validation and clamp updated from 1 to 0)
- setDisplayStatus(): when using sysfs backlight (not ddcutil), automatically save the current brightness before turning OFF and set it to 0, then restore it when turning ON

This avoids requiring external scripts to handle this case.

Closes #190 