### PR TITLE
feat: add webcam motion sensor via MQTT

### DIFF
--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -68,6 +68,7 @@ The necessary requirements for MQTT sensors to work are listed here:
 | Volume               | Device (non-dummy) `pactl get-default-sink` exists.                                                           | [#82](https://github.com/leukipp/touchkio/issues/82)                                                         |
 | Reboot               | Requires password-less `sudo` rights.                                                                         | [#39](https://github.com/leukipp/touchkio/issues/39)                                                         |
 | Shutdown             | Requires password-less `sudo` rights.                                                                         | [#39](https://github.com/leukipp/touchkio/issues/39)                                                         |
+| Motion               | Requires `motion` package installed and `--motion-device` argument pointing to a valid `/dev/video*` device.  | -                                                                                                             |
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Moreover, the device running the **kiosk application** also offers several **Hom
   - [x] Volume control for connected audio outputs.
   - [x] Execute system reboot and shutdown commands.
   - [x] Monitor battery, temperature, processor and memory usage.
+  - [x] Motion sensor binary using a connected USB or built-in webcam.
 
 The kiosk application can be executed with command line arguments to load a **Home Assistant dashboard in fullscreen** mode.
 Additionally, a **MQTT endpoint** can be defined, allowing the application to provide controls and sensors for the Linux device and the connected Touch Display.
@@ -157,6 +158,46 @@ For example:
 ```bash
 touchkio --web-url=http://192.168.1.42:8123 --mqtt-url=mqtt://192.168.1.42:1883 --mqtt-user=kiosk --mqtt-password=password
 ```
+
+### MOTION
+If your device has a USB or built-in webcam, TouchKio can expose a **Motion** binary sensor in Home Assistant.
+Motion detection is handled by the external [`motion`](https://motion-project.github.io) daemon, which writes detection state to a shared file that TouchKio watches.
+
+| Name                          | Default | Description                                                                      |
+| ----------------------------- | ------- | -------------------------------------------------------------------------------- |
+| `--motion-device` (Optional)  | -       | Path to the webcam device (e.g. `/dev/video0`). Enables the motion binary sensor. |
+
+**Requirements:** the `motion` package must be installed (`sudo apt install motion`) and the specified device must exist.
+
+**Setup:** configure `/etc/motion/motion.conf` to call two hook scripts on detection events:
+```
+on_event_start /usr/local/bin/kiosk-motion-start
+on_event_end   /usr/local/bin/kiosk-motion-end
+```
+
+Create the two hook scripts:
+```bash
+# /usr/local/bin/kiosk-motion-start
+#!/bin/bash
+echo "ON" > /tmp/kiosk_motion_state
+
+# /usr/local/bin/kiosk-motion-end
+#!/bin/bash
+echo "OFF" > /tmp/kiosk_motion_state
+```
+
+Make them executable and ensure the `motion` daemon user can write to `/tmp/kiosk_motion_state`:
+```bash
+sudo chmod +x /usr/local/bin/kiosk-motion-start /usr/local/bin/kiosk-motion-end
+echo "OFF" | sudo tee /tmp/kiosk_motion_state && sudo chmod 666 /tmp/kiosk_motion_state
+```
+
+Then start TouchKio with the device argument:
+```bash
+touchkio --web-url=http://192.168.1.42:8123 --mqtt-url=mqtt://192.168.1.42:1883 --mqtt-user=kiosk --mqtt-password=password --motion-device=/dev/video0
+```
+
+The **Motion** binary sensor will appear automatically in Home Assistant under the same TouchKio device as all other sensors.
 
 ## User Interface
 TouchKio provides a simple webview window designed specifically for Touch Displays. Electron apps are known to be resource intensive due to their architecture and the inclusion of a full web browser environment. If you just run the kiosk application without other heavy loads, everything should run smoothly.

--- a/js/hardware.js
+++ b/js/hardware.js
@@ -31,6 +31,11 @@ global.HARDWARE = global.HARDWARE || {
   audio: {
     device: null,
   },
+  motion: {
+    device: {
+      path: null,
+    },
+  },
 };
 
 /**
@@ -55,6 +60,7 @@ const init = async () => {
   HARDWARE.display.brightness.command = getDisplayBrightnessCommand();
   HARDWARE.display.brightness.value.max = getDisplayBrightnessMax();
   HARDWARE.audio.device = getAudioDevice();
+  HARDWARE.motion.device.path = getMotionDevicePath();
   HARDWARE.support = checkSupport();
   HARDWARE.initialized = true;
 
@@ -116,6 +122,11 @@ const init = async () => {
   console.info(
     `Keyboard Visibility [${HARDWARE.support.keyboardVisibility ? "dbus://sm/puri/OSK0" : unsupported}]:`,
     keyboardVisibilityInfo,
+  );
+  const motionSensorInfo = HARDWARE.support.motionSensor ? `${HARDWARE.motion.device.path} (motion)` : unsupported;
+  console.info(
+    `Motion Sensor [${HARDWARE.support.motionSensor ? HARDWARE.motion.device.path : unsupported}]:`,
+    motionSensorInfo,
   );
   process.stdout.write("\n");
 
@@ -297,6 +308,7 @@ const checkSupport = () => {
   const statusCommand = !!HARDWARE.display.status.command;
   const brightnessPath = !!HARDWARE.display.brightness.path && !!HARDWARE.display.brightness.value.max;
   const brightnessCommand = !!HARDWARE.display.brightness.command && !!HARDWARE.display.brightness.value.max;
+  const motionDevice = !!HARDWARE.motion.device.path;
 
   return {
     batteryLevel: batteryPath,
@@ -304,6 +316,7 @@ const checkSupport = () => {
     displayBrightness: sudo && statusPath && statusCommand && (brightnessPath || brightnessCommand),
     keyboardVisibility: keyboard,
     audioVolume: audioDevice,
+    motionSensor: motionDevice && commandExists("motion"),
     sudoRights: sudo,
     appUpdate: service && sudo && release,
   };
@@ -766,6 +779,19 @@ const getAudioDevice = () => {
 };
 
 /**
+ * Gets the webcam device path from the `--motion-device` argument.
+ *
+ * @returns {string|null} The webcam device path or null if not configured or not found.
+ */
+const getMotionDevicePath = () => {
+  const device = ARGS.motion_device || null;
+  if (device && fs.existsSync(device)) {
+    return device;
+  }
+  return null;
+};
+
+/**
  * Gets the default audio device volume using `pactl`.
  *
  * @returns {number|null} The default audio device volume as a percentage or null if an error occurs.
@@ -1212,6 +1238,7 @@ module.exports = {
   setAudioVolume,
   getKeyboardVisibility,
   setKeyboardVisibility,
+  getMotionDevicePath,
   checkPackageUpgrades,
   shutdownSystem,
   rebootSystem,

--- a/js/integration.js
+++ b/js/integration.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const mqtt = require("mqtt");
 const hardware = require("./hardware");
 const { app } = require("electron");
@@ -91,6 +92,7 @@ const init = async () => {
       initBatteryLevel();
       initPackageUpgrades();
       initLastActive();
+      initMotion();
 
       // Init client diagnostic
       initScreenshot();
@@ -1190,6 +1192,51 @@ const updateLastActive = async () => {
   };
   publishState("last_active", lastActive);
   publishAttributes("last_active", tracker);
+};
+
+/**
+ * Initializes the motion binary sensor.
+ * Publishes an MQTT discovery config and watches the motion state file written by
+ * the `motion` daemon's on_event_start/on_event_end hooks.
+ */
+const initMotion = () => {
+  if (!HARDWARE.support.motionSensor || ARGS.app_disable.includes("mqtt_motion")) {
+    removeConfig("binary_sensor", {
+      unique_id: `${INTEGRATION.node}_motion`,
+    });
+    return;
+  }
+  const stateFile = "/tmp/kiosk_motion_state";
+  const root = `${INTEGRATION.root}/motion`;
+  const config = {
+    name: "Motion",
+    unique_id: `${INTEGRATION.node}_motion`,
+    state_topic: `${root}/state`,
+    device_class: "motion",
+    payload_on: "ON",
+    payload_off: "OFF",
+    icon: "mdi:motion-sensor",
+    device: INTEGRATION.device,
+  };
+  publishConfig("binary_sensor", config);
+  updateMotion();
+  fs.watchFile(stateFile, { interval: 500 }, () => updateMotion());
+};
+
+/**
+ * Updates the motion binary sensor via the mqtt connection.
+ */
+const updateMotion = () => {
+  if (!HARDWARE.support.motionSensor || ARGS.app_disable.includes("mqtt_motion")) {
+    return;
+  }
+  let state = "OFF";
+  try {
+    state = fs.readFileSync("/tmp/kiosk_motion_state", "utf8").trim() === "ON" ? "ON" : "OFF";
+  } catch {
+    // state file absent — default to no motion
+  }
+  publishState("motion", state);
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds a **Motion** binary sensor that appears in Home Assistant alongside all other TouchKio sensors, grouped under the same device.

When `--motion-device` is pointed at a valid `/dev/video*` webcam and the `motion` package is installed, TouchKio:

1. Publishes an MQTT discovery config for a `binary_sensor` with `device_class: motion`
2. Watches `/tmp/kiosk_motion_state` via `fs.watchFile` and publishes state changes within ~500ms
3. Cleans up the discovery config on disable via `--app-disable=mqtt_motion`

State is written to `/tmp/kiosk_motion_state` by two small hook scripts called from the `motion` daemon's `on_event_start` / `on_event_end` directives.

## Design rationale

- **No new npm dependencies** — motion detection stays out-of-process in the `motion` daemon, which already handles threshold tuning, event debouncing (`event_gap`), and V4L2 device management
- **Consistent with existing patterns** — `HARDWARE.support.motionSensor` follows the same detection-and-guard pattern used by `batteryLevel`, `audioVolume`, etc.; `initMotion`/`updateMotion` follow the same structure as every other sensor in `integration.js`
- **File-based IPC** — the same approach already used for display brightness monitoring (`fs.watchFile` / `fs.watch` in `hardware.js`)
- **Disableable** — respects `--app-disable=mqtt_motion` like all other MQTT entities

## Changes

| File | Change |
|------|--------|
| `js/hardware.js` | `HARDWARE.motion` global, `getMotionDevicePath()`, `motionSensor` in `checkSupport()`, startup logging |
| `js/integration.js` | `initMotion()`, `updateMotion()`, called after `initLastActive()` |
| `README.md` | MOTION configuration section with full setup instructions |
| `HARDWARE.md` | Motion row in the features requirements table |

## Test setup

Tested on Raspberry Pi 4 Model B (arm64), Raspberry Pi OS Bookworm, `motion` 4.7.0, USB webcam at `/dev/video0`.

```bash
touchkio --web-url=http://ha.local:8123 \
         --mqtt-url=mqtt://ha.local:1883 \
         --mqtt-user=kiosk --mqtt-password=password \
         --motion-device=/dev/video0
```

The Motion entity appeared immediately under the TouchKio device in Home Assistant and toggled correctly on detection events.