### PR TITLE
Add configurable USB power control via MQTT using uhubctl (#1)

### DIFF
--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -138,6 +138,21 @@ The necessary requirements for MQTT sensors to work are listed here:
 
 </details>
 
+### USB Power
+
+<details><summary>USB power can't be controlled through MQTT.</summary>
+
+  - Install `uhubctl` (`sudo apt install uhubctl`) and configure hub access using one of the following options:
+    - **Option A (recommended):** Copy [52-usb.rules](https://github.com/mvp/uhubctl/blob/master/udev/rules.d/52-usb.rules) to `/etc/udev/rules.d/`, add the kiosk user to the `dialout` group (`sudo usermod -a -G dialout $USER`), apply with `sudo udevadm trigger --attr-match=subsystem=usb`, and set `"usb_power_sudo": "false"` in `Arguments.json`.
+    - **Option B:** Add passwordless sudo for `/usr/bin/uhubctl` and set `"usb_power_sudo": "true"` in `Arguments.json`.
+  - On Raspberry Pi 4B, the onboard hub typically uses location `1-1`. Discover locations by running `uhubctl` (or `sudo uhubctl` if rules are not yet applied).
+  - Make sure the configured command works on the terminal before expecting the MQTT entity to work:
+    - `uhubctl -a 0 -l 1-1` turns USB power off.
+    - `uhubctl -a 1 -l 1-1` turns USB power on.
+  - For Pi 4B onboard hubs, uhubctl documents vendor IDs `2109` and `1d6b` in its README if you need vendor-specific udev rules.
+
+</details>
+
 ### Touch
 
 <details><summary>Automated screen blanking on inactivity.</summary>

--- a/README.md
+++ b/README.md
@@ -158,6 +158,32 @@ For example:
 touchkio --web-url=http://192.168.1.42:8123 --mqtt-url=mqtt://192.168.1.42:1883 --mqtt-user=kiosk --mqtt-password=password
 ```
 
+### USB Power
+To control USB hub port power through Home Assistant (e.g. on a Raspberry Pi), configure the following optional arguments:
+| Name                            | Default | Description                                                                                      |
+| ------------------------------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `--usb-power-location`          | `1-1`   | Comma-separated hub locations for `uhubctl -l` (e.g. `1-1` or `1-1,2-1`)                         |
+| `--usb-power-ports` (Optional)  | -       | Comma/range port list for `uhubctl -p` (e.g. `1`, `1,3`, `1-4`). Empty = all ports on each hub  |
+| `--usb-power-sudo` (Optional)   | `false` | Run `uhubctl` via `sudo` (`true`) or as the kiosk user (`false`, requires udev rules)            |
+
+The **USB Power** MQTT entity is a light with on/off support. Disable it with `--app-disable=mqtt_usb_power`.
+
+For example:
+```bash
+touchkio --web-url=http://192.168.1.42:8123 --mqtt-url=mqtt://192.168.1.42:1883 --mqtt-user=kiosk --mqtt-password=password --usb-power-location=1-1
+```
+
+In the `~/.config/touchkio/Arguments.json` file:
+```json
+{
+  "usb_power_location": ["1-1"],
+  "usb_power_ports": "2",
+  "usb_power_sudo": "false"
+}
+```
+
+See [HARDWARE.md](HARDWARE.md) for udev rules and sudo setup.
+
 ## User Interface
 TouchKio provides a simple webview window designed specifically for Touch Displays. Electron apps are known to be resource intensive due to their architecture and the inclusion of a full web browser environment. If you just run the kiosk application without other heavy loads, everything should run smoothly.
 

--- a/index.js
+++ b/index.js
@@ -182,6 +182,18 @@ const initArgs = async () => {
   if (!Array.isArray(args.app_reset)) {
     args.app_reset = args.app_reset.split(",").map((reset) => reset.trim());
   }
+  if (args.usb_power_location && !Array.isArray(args.usb_power_location)) {
+    args.usb_power_location = args.usb_power_location
+      .split(",")
+      .map((location) => location.trim())
+      .filter(Boolean);
+  }
+  if (args.usb_power_ports === "") {
+    delete args.usb_power_ports;
+  }
+  if ("usb_power_sudo" in args) {
+    args.usb_power_sudo = args.usb_power_sudo === "true" || args.usb_power_sudo === true ? "true" : "false";
+  }
 
   // Calculate arguments hash
   const argsFileHash = crypto.createHash("sha256").update(JSON.stringify(args)).digest("hex");
@@ -335,6 +347,26 @@ const promptArgs = async (proc) => {
       fallback: "homeassistant",
     },
     {
+      key: "usb_power",
+      question: "\nEnable USB power control via MQTT?",
+      fallback: "y/N",
+    },
+    {
+      key: "usb_power_location",
+      question: "Enter USB hub location(s)",
+      fallback: "1-1",
+    },
+    {
+      key: "usb_power_ports",
+      question: "Enter USB port number(s) (optional)",
+      fallback: "",
+    },
+    {
+      key: "usb_power_sudo",
+      question: "Use sudo for uhubctl? (No if udev rules are configured)",
+      fallback: "y/N",
+    },
+    {
       key: "check",
       question: "\nEverything looks good?",
       fallback: "Y/n",
@@ -351,8 +383,29 @@ const promptArgs = async (proc) => {
         const answer = await read.question(prompt);
         const value = (answer.trim() || fallback.match(/[YN]/)[0]).toLowerCase();
         if (!["y", "yes"].includes(value)) {
-          ignore = ignore.concat(["mqtt_url", "mqtt_user", "mqtt_password", "mqtt_discovery"]);
+          ignore = ignore.concat([
+            "mqtt_url",
+            "mqtt_user",
+            "mqtt_password",
+            "mqtt_discovery",
+            "usb_power",
+            "usb_power_location",
+            "usb_power_ports",
+            "usb_power_sudo",
+          ]);
         }
+      } else if (key === "usb_power") {
+        const prompt = `${question} (${fallback}): `;
+        const answer = await read.question(prompt);
+        const value = (answer.trim() || fallback.match(/[YN]/)[0]).toLowerCase();
+        if (!["y", "yes"].includes(value)) {
+          ignore = ignore.concat(["usb_power_location", "usb_power_ports", "usb_power_sudo"]);
+        }
+      } else if (key === "usb_power_sudo") {
+        const prompt = `${question} (${fallback}): `;
+        const answer = await read.question(prompt);
+        const value = (answer.trim() || fallback.match(/[YN]/)[0]).toLowerCase();
+        args[key] = ["y", "yes"].includes(value) ? "true" : "false";
       } else if (key === "check") {
         const json = JSON.stringify(args, null, 2);
         const prompt = `${question}\n${json}\n(${fallback}): `;
@@ -367,6 +420,8 @@ const promptArgs = async (proc) => {
         const value = answer.trim() || fallback;
         if (key === "web_url") {
           args[key] = value.split(",").map((v) => v.trim());
+        } else if (key === "usb_power_ports" && !value) {
+          continue;
         } else {
           args[key] = value;
         }

--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,10 @@ echo -e "\nInstalling the latest release..."
 command -v apt &> /dev/null || { echo "Package manager apt was not found."; exit 1; }
 sudo apt install -y "$DEB_PATH" || { echo "Installation of .deb file failed."; exit 1; }
 
+# Install optional dependency for USB power control
+echo -e "\nInstalling optional dependency uhubctl for USB power control..."
+sudo apt install -y uhubctl || echo "uhubctl not installed; USB power control will be unavailable."
+
 # Create the systemd user service
 echo -e "\nCreating systemd user service..."
 

--- a/js/hardware.js
+++ b/js/hardware.js
@@ -39,6 +39,14 @@ global.HARDWARE = global.HARDWARE || {
       input: null,
     },
   },
+  usb: {
+    power: {
+      locations: [],
+      ports: null,
+      sudo: false,
+      value: { status: null },
+    },
+  },
 };
 
 /**
@@ -65,6 +73,9 @@ const init = async () => {
   HARDWARE.display.brightness.value.max = getDisplayBrightnessMax();
   HARDWARE.audio.device.output = getAudioOutput();
   HARDWARE.audio.device.input = getAudioInput();
+  HARDWARE.usb.power.locations = getUsbPowerLocations();
+  HARDWARE.usb.power.ports = getUsbPowerPorts();
+  HARDWARE.usb.power.sudo = getUsbPowerSudo();
   HARDWARE.support = checkSupport();
   HARDWARE.initialized = true;
 
@@ -139,6 +150,16 @@ const init = async () => {
     `Keyboard Visibility [${HARDWARE.support.keyboardVisibility ? "dbus://sm/puri/OSK0" : unsupported}]:`,
     keyboardVisibilityInfo,
   );
+  const usbPowerLabel = getUsbPowerCommandLabel();
+  const usbPower = `${getUsbPowerStatus()} (${usbPowerLabel})`;
+  const usbPowerInfo = HARDWARE.support.usbPower ? usbPower : unsupported;
+  console.info(
+    `USB Power [${HARDWARE.support.usbPower ? HARDWARE.usb.power.locations.join(",") : unsupported}]:`,
+    usbPowerInfo,
+  );
+  if (HARDWARE.usb.power.locations.length && !HARDWARE.support.usbPower) {
+    logUsbPowerHint();
+  }
   process.stdout.write("\n");
 
   // Monitor audio output and input volume
@@ -179,6 +200,18 @@ const init = async () => {
   setDisplayStatus("ON", () => {
     interval(update, 1 * 1000);
   });
+
+  // Monitor USB power changes (5s)
+  if (HARDWARE.support.usbPower) {
+    interval(async () => {
+      const status = getUsbPowerStatus();
+      if (status && status !== HARDWARE.usb.power.value.status) {
+        HARDWARE.usb.power.value.status = status;
+        console.info("Update USB Power Status:", status);
+        EVENTS.emit("updateUsbPower");
+      }
+    }, 5 * 1000);
+  }
 
   return true;
 };
@@ -326,6 +359,7 @@ const checkSupport = () => {
     microphoneVolume: audioInput,
     appUpdate: sudo && service && release,
     sudoRights: sudo,
+    usbPower: commandExists("uhubctl") && HARDWARE.usb.power.locations.length > 0 && uhubctlProbe(),
   };
 };
 
@@ -738,6 +772,252 @@ const setDisplayStatus = (status, callback = null) => {
       execAsyncCommand("xset", ["dpms", "force", status.toLowerCase()], callback);
       break;
   }
+};
+
+/**
+ * Gets configured USB hub locations from arguments.
+ *
+ * @returns {Array<string>} USB hub locations for uhubctl -l.
+ */
+const getUsbPowerLocations = () => {
+  const value = ARGS.usb_power_location;
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.map((location) => location.trim()).filter(Boolean);
+  }
+  return value
+    .split(",")
+    .map((location) => location.trim())
+    .filter(Boolean);
+};
+
+/**
+ * Gets configured USB port filter from arguments.
+ *
+ * @returns {string|null} USB port list for uhubctl -p or null for all ports.
+ */
+const getUsbPowerPorts = () => {
+  const value = ARGS.usb_power_ports;
+  if (!value || (typeof value === "string" && !value.trim())) {
+    return null;
+  }
+  return typeof value === "string" ? value.trim() : String(value);
+};
+
+/**
+ * Gets whether uhubctl should run with sudo from arguments.
+ *
+ * @returns {bool} True if uhubctl commands should use sudo.
+ */
+const getUsbPowerSudo = () => {
+  return ARGS.usb_power_sudo === "true" || ARGS.usb_power_sudo === true;
+};
+
+/**
+ * Gets the command label used for USB power logging.
+ *
+ * @returns {string} Command label for logs.
+ */
+const getUsbPowerCommandLabel = () => {
+  return HARDWARE.usb.power.sudo ? "sudo uhubctl" : "uhubctl";
+};
+
+/**
+ * Executes uhubctl synchronously with the configured elevation mode.
+ *
+ * @param {Array<string>} args - uhubctl arguments.
+ * @returns {string|null} Command output or null on error.
+ */
+const execSyncUhubctl = (args) => {
+  if (HARDWARE.usb.power.sudo) {
+    return execSyncCommand("sudo", ["uhubctl", ...args]);
+  }
+  return execSyncCommand("uhubctl", args);
+};
+
+/**
+ * Executes uhubctl asynchronously with the configured elevation mode.
+ *
+ * @param {Array<string>} args - uhubctl arguments.
+ * @param {Function} callback - A callback function that receives the output or error.
+ * @returns {Object} The spawned process object.
+ */
+const execAsyncUhubctl = (args, callback = null) => {
+  if (HARDWARE.usb.power.sudo) {
+    return execAsyncCommand("sudo", ["uhubctl", ...args], callback);
+  }
+  return execAsyncCommand("uhubctl", args, callback);
+};
+
+/**
+ * Parses uhubctl port status output.
+ *
+ * @param {string} output - uhubctl command output.
+ * @returns {Object} Port numbers mapped to ON/OFF status.
+ */
+const parseUhubctlPorts = (output) => {
+  const ports = {};
+  const regex = /^\s*Port\s+(\d+):\s+\w+\s+(power|off)/gm;
+  let match = null;
+  while ((match = regex.exec(output)) !== null) {
+    ports[match[1]] = match[2] === "power" ? "ON" : "OFF";
+  }
+  return ports;
+};
+
+/**
+ * Expands a uhubctl port filter into individual port numbers.
+ *
+ * @param {string|null} portFilter - Optional comma/range port filter.
+ * @returns {Array<string>|null} Port numbers or null for all ports.
+ */
+const expandPortFilter = (portFilter) => {
+  if (!portFilter) {
+    return null;
+  }
+  const ports = [];
+  for (const part of portFilter.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (trimmed.includes("-")) {
+      const [start, end] = trimmed.split("-").map((value) => parseInt(value, 10));
+      if (!isNaN(start) && !isNaN(end)) {
+        for (let port = start; port <= end; port++) {
+          ports.push(String(port));
+        }
+      }
+    } else {
+      ports.push(trimmed);
+    }
+  }
+  return ports.length ? ports : null;
+};
+
+/**
+ * Aggregates port statuses into a single ON/OFF value.
+ *
+ * @param {Object} ports - Port numbers mapped to ON/OFF status.
+ * @param {string|null} portFilter - Optional comma-separated port filter.
+ * @returns {string|null} Aggregated status or null if no ports were found.
+ */
+const aggregateUsbPowerStatus = (ports, portFilter = null) => {
+  const portNumbers = expandPortFilter(portFilter) || Object.keys(ports);
+  const statuses = portNumbers.map((port) => ports[port]).filter(Boolean);
+  if (!statuses.length) {
+    return null;
+  }
+  if (statuses.every((status) => status === "ON")) {
+    return "ON";
+  }
+  if (statuses.every((status) => status === "OFF")) {
+    return "OFF";
+  }
+  return "OFF";
+};
+
+/**
+ * Probes whether uhubctl works with the configured elevation mode.
+ *
+ * @returns {bool} True if uhubctl can query the configured hub location.
+ */
+const uhubctlProbe = () => {
+  if (!commandExists("uhubctl") || !HARDWARE.usb.power.locations.length) {
+    return false;
+  }
+  if (HARDWARE.usb.power.sudo && !sudoRights()) {
+    return false;
+  }
+  const output = execSyncUhubctl(["-l", HARDWARE.usb.power.locations[0]]);
+  return output !== null && /Port\s+\d+:/.test(output);
+};
+
+/**
+ * Logs setup hints when USB power is configured but unavailable.
+ */
+const logUsbPowerHint = () => {
+  if (HARDWARE.usb.power.sudo) {
+    console.warn(
+      "USB power control requires passwordless sudo for uhubctl or set usb_power_sudo to false with udev rules.",
+    );
+    return;
+  }
+  console.warn(
+    "USB power control requires udev rules for uhubctl or set usb_power_sudo to true with passwordless sudo.",
+  );
+  console.warn("See https://github.com/mvp/uhubctl/blob/master/udev/rules.d/52-usb.rules");
+};
+
+/**
+ * Gets the USB hub power status using `uhubctl`.
+ *
+ * @returns {string|null} USB power status ON/OFF or null if unavailable.
+ */
+const getUsbPowerStatus = () => {
+  if (!HARDWARE.support.usbPower) {
+    return null;
+  }
+  const statuses = [];
+  for (const location of HARDWARE.usb.power.locations) {
+    const output = execSyncUhubctl(["-l", location]);
+    if (!output) {
+      return null;
+    }
+    const status = aggregateUsbPowerStatus(parseUhubctlPorts(output), HARDWARE.usb.power.ports);
+    if (!status) {
+      return null;
+    }
+    statuses.push(status);
+  }
+  if (!statuses.length) {
+    return null;
+  }
+  if (statuses.every((status) => status === "ON")) {
+    return "ON";
+  }
+  return "OFF";
+};
+
+/**
+ * Sets the USB hub power status using `uhubctl`.
+ *
+ * @param {string} status - The desired status ('ON' or 'OFF').
+ * @param {Function} callback - A callback function that receives the output or error.
+ */
+const setUsbPowerStatus = (status, callback = null) => {
+  if (!HARDWARE.support.usbPower) {
+    if (typeof callback === "function") callback(null, "Not supported");
+    return;
+  }
+  if (!["ON", "OFF"].includes(status)) {
+    console.error("Status must be 'ON' or 'OFF'");
+    if (typeof callback === "function") callback(null, "Invalid status");
+    return;
+  }
+  const action = status === "ON" ? "1" : "0";
+  const locations = HARDWARE.usb.power.locations;
+  const runLocation = (index) => {
+    if (index >= locations.length) {
+      HARDWARE.usb.power.value.status = status;
+      if (typeof callback === "function") callback("", null);
+      return;
+    }
+    const args = ["-a", action, "-l", locations[index]];
+    if (HARDWARE.usb.power.ports) {
+      args.push("-p", HARDWARE.usb.power.ports);
+    }
+    execAsyncUhubctl(args, (reply, error) => {
+      if (error) {
+        if (typeof callback === "function") callback(null, error);
+        return;
+      }
+      runLocation(index + 1);
+    });
+  };
+  runLocation(0);
 };
 
 /**
@@ -1428,6 +1708,8 @@ module.exports = {
   setMicrophoneVolume,
   getKeyboardVisibility,
   setKeyboardVisibility,
+  getUsbPowerStatus,
+  setUsbPowerStatus,
   checkPackageUpgrades,
   shutdownSystem,
   rebootSystem,

--- a/js/integration.js
+++ b/js/integration.js
@@ -72,6 +72,7 @@ const init = async () => {
       initKiosk();
       initTheme();
       initDisplay();
+      initUsbPower();
       initVolume();
       initMicrophone();
       initKeyboard();
@@ -119,6 +120,7 @@ const init = async () => {
         updateDisplay();
         updateLastActive();
       });
+      EVENTS.on("updateUsbPower", updateUsbPower);
       EVENTS.on("updateScreenshot", updateScreenshot);
       EVENTS.on("consoleLog", updateErrors);
     })
@@ -544,6 +546,54 @@ const updateDisplay = async () => {
   const brightness = hardware.getDisplayBrightness();
   publishState("display/brightness", brightness);
   publishState("display/power", status);
+};
+
+/**
+ * Initializes the USB power status and handles the execute logic.
+ */
+const initUsbPower = () => {
+  const root = `${INTEGRATION.root}/usb_power`;
+  const config = {
+    name: "USB Power",
+    unique_id: `${INTEGRATION.node}_usb_power`,
+    command_topic: `${root}/power/set`,
+    state_topic: `${root}/power/state`,
+    supported_color_modes: ["onoff"],
+    icon: "mdi:usb-port",
+    platform: "light",
+    device: INTEGRATION.device,
+  };
+  if (!HARDWARE.support.usbPower || ARGS.app_disable.includes("mqtt_usb_power")) {
+    removeConfig("light", config);
+    return;
+  }
+  publishConfig("light", config)
+    .on("message", (topic, message) => {
+      if (topic === config.command_topic) {
+        const status = message.toString();
+        console.verbose("Set USB Power Status:", status);
+        hardware.setUsbPowerStatus(status, (reply, error) => {
+          if (!error) {
+            updateUsbPower();
+          } else {
+            console.warn("Command Failed:", error);
+          }
+        });
+      }
+    })
+    .subscribe(config.command_topic);
+  updateUsbPower();
+};
+
+/**
+ * Updates the USB power status via the mqtt connection.
+ */
+const updateUsbPower = async () => {
+  if (ARGS.app_disable.includes("mqtt_usb_power")) {
+    return;
+  }
+  const status = hardware.getUsbPowerStatus();
+  publishState("usb_power/power", status);
 };
 
 /**


### PR DESCRIPTION
Expose USB hub power as a Home Assistant MQTT light entity, mirroring the display toggle pattern. Support configurable hub locations, optional port filters, and optional sudo elevation with udev-based defaults.

Includes setup prompts, install.sh uhubctl dependency, and documentation.

This allows for users to toggle USB power on and off for various reasons. My use case was that my display is USB powered and running direct from the Pi. Toggling via USB power gives it a cleaner toggle off and on than the standard display toggle in the current implementation.

Disclaimer: Code was written using Cursor AI agent, but reviewed and verified by myself.