### PR TITLE
feat: add web_window argument to configure startup window mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,13 @@ The available arguments to control the kiosk application via terminal are as fol
 | `--web-theme` (Optional)  | `dark`  | Theme settings of the web browser (`light` or `dark`)                                                      |
 | `--web-zoom` (Optional)   | `1.25`  | Zoom settings of the web browser (`1.0` is `100%`)                                                         |
 | `--web-widget` (Optional) | `true`  | Enables the sidebar widget (`true` or `false`)                                                             |
+| `--web-window` (Optional) | `fullscreen` | Window mode on startup (`fullscreen`, `maximized` or `framed`)                                         |
 
 These arguments allow you to customize the appearance of the web browser view.
 
 For example:
 ```bash
-touchkio --web-url=http://192.168.1.42:8123 --web-theme=light --web-zoom=1.0
+touchkio --web-url=http://192.168.1.42:8123 --web-theme=light --web-zoom=1.0 --web-window=maximized
 ```
 
 > <a id="foot1"></a><a href="#ref1">[1]</a>: This doesn't necessarily have to be a Home Assistant Url.

--- a/index.js
+++ b/index.js
@@ -310,6 +310,11 @@ const promptArgs = async (proc) => {
       fallback: "true",
     },
     {
+      key: "web_window",
+      question: "Enter WEB window mode (fullscreen, maximized, framed)",
+      fallback: "fullscreen",
+    },
+    {
       key: "mqtt",
       question: "\nConnect to MQTT Broker?",
       fallback: "y/N",

--- a/js/webview.js
+++ b/js/webview.js
@@ -59,6 +59,7 @@ const init = async () => {
   const widget = ARGS.web_widget ? ARGS.web_widget === "true" : true;
   const theme = ["light", "dark"].includes(ARGS.web_theme) ? ARGS.web_theme : "dark";
   const zoom = (!isNaN(parseFloat(ARGS.web_zoom)) ? parseFloat(ARGS.web_zoom) : 1.25) * 100;
+  const windowMode = ["fullscreen", "maximized", "framed"].includes(ARGS.web_window) ? ARGS.web_window : "fullscreen";
   const urls = [loaderHtml(40, 1.0, theme), ...ARGS.web_url];
 
   // Init global controls
@@ -66,6 +67,7 @@ const init = async () => {
   WEBVIEW.pagerEnabled = widget;
   WEBVIEW.widgetEnabled = widget;
   WEBVIEW.navigationEnabled = widget;
+  WEBVIEW.windowStatus = windowMode.charAt(0).toUpperCase() + windowMode.slice(1);
 
   // Init global views
   WEBVIEW.views = [];
@@ -1054,9 +1056,9 @@ const viewEvents = async () => {
       return true;
     }
 
-    // Set window status to fullscreen
+    // Set window status to the configured startup mode
     if (i === 0 && !("app_debug" in ARGS)) {
-      WEBVIEW.window.setStatus("Fullscreen");
+      WEBVIEW.window.setStatus(WEBVIEW.windowStatus);
     }
 
     // Hide loader and show first view
@@ -1225,7 +1227,7 @@ const appEvents = async () => {
     if (visibility === "ON" && ["Fullscreen"].includes(status)) {
       WEBVIEW.window.setStatus("Maximized");
     } else if (visibility === "OFF" && ["Maximized"].includes(status)) {
-      WEBVIEW.window.setStatus("Fullscreen");
+      WEBVIEW.window.setStatus(WEBVIEW.windowStatus);
     }
   });
 


### PR DESCRIPTION
## Summary

Closes #222.

TouchKio currently always enters **fullscreen** on startup. On a shared desktop (e.g. a family PC) this fights with other applications. This PR adds an optional `web_window` argument to choose the startup window mode.

| Value | Behaviour |
| --- | --- |
| `fullscreen` (default) | Current behaviour — unchanged |
| `maximized` | Starts maximized, so other apps stay reachable |
| `framed` | Starts as a normal (framed) window |

The values map directly onto the existing `setStatus()` window states, so no new window logic was introduced.

## Usage

```bash
touchkio --web-url=http://192.168.1.42:8123 --web-window=maximized
```

Or in `~/.config/touchkio/Arguments.json`:

```json
{ "web_window": "maximized" }
```

It is also offered in the interactive setup prompt (`touchkio --setup`), and persists to `Arguments.json` like every other argument.

## Changes

- **`index.js`** — new `web_window` entry in `promptArgs()` (fallback `fullscreen`).
- **`js/webview.js`** — normalise the argument to a valid window status (`WEBVIEW.windowStatus`) and use it at the startup transition. The keyboard-hide restore handler also restores to the configured mode instead of hard-coding fullscreen, so a chosen `maximized`/`framed` mode is not silently forced back to fullscreen when the on-screen keyboard disappears.
- **`README.md`** — documented the new argument.

## Compatibility

Fully backward compatible: an unset or unrecognised value falls back to `fullscreen`, reproducing today's exact behaviour.

## Testing

- Reviewed the diff and validated the mode-to-status mapping (`fullscreen|maximized|framed` → `Fullscreen|Maximized|Framed`, invalid/unset → `Fullscreen`).
- GUI/on-device behaviour has not been exercised in CI (headless environment); I'd suggest a quick check on a real device with `--web-window=maximized` and `--web-window=framed` before merge.