### PR TITLE
fix: display brightness reporting as unsupported when it is possible to support

### DIFF
--- a/js/hardware.js
+++ b/js/hardware.js
@@ -610,8 +610,8 @@ const getDisplayStatusCommand = () => {
   const mapping = {
     wayland: [
       { command: "ddcutil", desktops: ["*"] },
-      { command: "wlopm", desktops: ["labwc", "wayfire", "unknown"] },
-      { command: "kscreen-doctor", desktops: ["kde", "plasma", "unknown"] },
+      { command: "wlopm", desktops: ["labwc", "wayfire", "unknown", "*"] },
+      { command: "kscreen-doctor", desktops: ["kde", "plasma", "unknown", "*"] },
     ],
     x11: [
       { command: "ddcutil", desktops: ["*"] },
@@ -761,6 +761,23 @@ const getDisplayBrightnessPath = () => {
 };
 
 /**
+ * Checks if the current session has access to the display brightness files.
+ * 
+ * @returns {boolean} True if the session has access to the display brightness files, false otherwise.
+ */
+const videoRights = () => {
+  const user = HARDWARE.session.user;
+  if (!user) {
+    return false;
+  }
+  const groups = execSyncCommand("groups", [user]);
+  if (!groups) {
+    return false;
+  }
+  return groups.split(":")[1].split(" ").includes("video");
+}
+
+/**
  * Gets the available display brightness command checking for `ddcutil` and `tee`.
  *
  * @returns {string|null} The display brightness command or null if nothing was found.
@@ -794,7 +811,7 @@ const getDisplayBrightnessCommand = () => {
           }
           break;
         case "tee":
-          if (!sudoRights()) {
+          if (!(sudoRights() || videoRights())) {
             break;
           }
           if (HARDWARE.display.brightness.path) {
@@ -888,7 +905,15 @@ const setDisplayBrightness = (brightness, callback = null) => {
       const max = HARDWARE.display.brightness.value.max || 1;
       const file = path.join(HARDWARE.display.brightness.path, "brightness");
       const value = Math.max(1, Math.min(Math.round((brightness / 100) * max), max));
-      const proc = execAsyncCommand("sudo", ["tee", file], callback);
+      let proc;
+      if (videoRights()) {
+        // Don't need sudo
+        proc = execAsyncCommand("tee", [file], callback);
+      }
+      else {
+        // Fall back to sudo
+        proc = execAsyncCommand("sudo", ["tee", file], callback);
+      }
       proc.stdin.write(value.toString());
       proc.stdin.end();
       return;

--- a/js/hardware.js
+++ b/js/hardware.js
@@ -770,11 +770,19 @@ const videoRights = () => {
   if (!user) {
     return false;
   }
-  const groups = execSyncCommand("groups", [user]);
-  if (!groups) {
+  try {
+    const brightnessPath = HARDWARE.display.brightness.path;
+    if (!brightnessPath) {
+      return false;
+    }
+    const brightnessFile = path.join(brightnessPath, "brightness");
+    const maxBrightnessFile = path.join(brightnessPath, "max_brightness");
+    fs.accessSync(brightnessFile, fs.constants.R_OK | fs.constants.W_OK);
+    fs.accessSync(maxBrightnessFile, fs.constants.R_OK);
+    return true;
+  } catch (err) {
     return false;
   }
-  return groups.split(":")[1].split(" ").includes("video");
 }
 
 /**


### PR DESCRIPTION
## Changes

add wild card (*) to `desktops` for `wlopm` and kscreen-doctor` as these should be desktop agnostic anyway in wayland (e.g I'm on COSMIC)

`sudo` rights aren't needed to adjust display brightness if the user has access to the correct files


## Note

Checking for passwordless `sudo` at session start to get the command is likely to fail as some shells have a timeout on passwordless `sudo`. Therefore, passwordless `sudo` could be present at the start of the `touchkio` session, then could be revoked during the session