### PR TITLE
fix(ddc): publish power/state OFF for monitors returning standby on power-off

### DIFF
--- a/js/hardware.js
+++ b/js/hardware.js
@@ -670,10 +670,9 @@ const getDisplayStatus = () => {
   switch (HARDWARE.display.status.command) {
     case "ddcutil":
       const ddcutil = execSyncCommand("sudo", ["ddcutil", "getvcp", "0xD6", "--brief"]);
-      const match = ddcutil !== null ? ddcutil.match(/VCP D6 \S+ x0?([14])/) : null;
+      const match = ddcutil !== null ? ddcutil.match(/VCP D6 \S+ x([0-9a-f]+)/i) : null;
       if (match) {
-        const output = match[1] === "1";
-        return output ? "ON" : "OFF";
+        return parseInt(match[1], 16) === 0x01 ? "ON" : "OFF";
       }
       break;
     case "wlopm":
@@ -722,7 +721,7 @@ const setDisplayStatus = (status, callback = null) => {
   }
   switch (HARDWARE.display.status.command) {
     case "ddcutil":
-      execAsyncCommand("sudo", ["ddcutil", "setvcp", "0xD6", status === "ON" ? "1" : "4"], (reply, error) => {
+      execAsyncCommand("sudo", ["ddcutil", "setvcp", "0xD6", status === "ON" ? "1" : "5"], (reply, error) => {
         fs.writeFileSync(path.join(HARDWARE.display.status.path, "dpms"), status.toLowerCase());
         fs.writeFileSync(path.join(HARDWARE.display.status.path, "status"), status.toLowerCase());
         if (typeof callback === "function") callback(reply, error);


### PR DESCRIPTION
## Problem

When sending a power-off command, TouchKio executes `ddcutil setvcp D6 4` successfully and the monitor turns off physically, but `power/state OFF` is never published to MQTT. Home Assistant always shows the display as on.

**Root cause:** the DDC parser uses regex `/VCP D6 \S+ x0?([14])/` which only matches `x01` (ON) and `x04` (OFF). Some monitors return different values:

| Command sent | Monitor reports (`getvcp D6`) | Old regex match |
|---|---|---|
| `setvcp D6 1` | `x01` | ✓ → publishes ON |
| `setvcp D6 4` | `x02` (Standby) | ✗ → null → no publish |
| `setvcp D6 5` | `x04` | ✓ → publishes OFF |

Tested on **Raspberry Pi 5** with **Atlantis A05-T22A-VHDM** monitor via `card1-HDMI-A-2`.

## MQTT before fix

```
touchkio/.../display/power/state ON   ← initial state
touchkio/.../display/power/set   OFF  ← HA sends off command
                                       ← silence: state OFF never published
touchkio/.../display/power/set   ON
touchkio/.../display/power/state ON
```

## Changes

**`js/hardware.js` — `getDisplayStatus()`:** replace narrow character-class regex with full hex capture and integer comparison. Any value other than `0x01` is treated as OFF, making the parser robust across monitor implementations.

**`js/hardware.js` — `setDisplayStatus()`:** switch the off command from DDC value `4` (DPM Standby on this monitor) to value `5` (DPM Off), which causes the Atlantis T22A to report `x04` on the subsequent `getvcp`.

## MQTT after fix

```
touchkio/.../display/power/state ON   ← initial state
touchkio/.../display/power/set   OFF  ← HA sends off command
touchkio/.../display/power/state OFF  ← ✓ now published correctly
touchkio/.../display/power/set   ON
touchkio/.../display/power/state ON
```

Closes #226